### PR TITLE
Add Order Details Page for Logged-in Users

### DIFF
--- a/WebContent/orderDetails.jsp
+++ b/WebContent/orderDetails.jsp
@@ -1,0 +1,91 @@
+<%@ page language="java" contentType="text/html; charset=ISO-8859-1"
+	pageEncoding="ISO-8859-1"%>
+<%@ page
+	import="com.mehedi.service.impl.*,com.mehedi.service.*,com.mehedi.beans.*,java.util.*,javax.servlet.ServletOutputStream,java.io.*"%>
+<!DOCTYPE html>
+<html>
+<head>
+<title>Order Details</title>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<link rel="stylesheet"
+	href="https://maxcdn.bootstrapcdn.com/bootstrap/3.4.0/css/bootstrap.min.css">
+<script
+	src="https://ajax.googleapis.com/ajax/libs/jquery/3.4.1/jquery.min.js"></script>
+<script
+	src="https://maxcdn.bootstrapcdn.com/bootstrap/3.4.0/js/bootstrap.min.js"></script>
+<link rel="stylesheet" href="css/changes.css">
+</head>
+<body style="background-color: #E6F9E6;">
+
+	<%
+	/* Checking the user credentials */
+	String userName = (String) session.getAttribute("username");
+	String password = (String) session.getAttribute("password");
+
+	if (userName == null || password == null) {
+
+		response.sendRedirect("login.jsp?message=Session Expired, Login Again!!");
+
+	}
+
+	OrderService dao = new OrderServiceImpl();
+	List<OrderDetails> orders = dao.getAllOrderDetails(userName);
+	%>
+
+
+
+	<jsp:include page="header.jsp" />
+
+	<!-- <script>document.getElementById('mycart').innerHTML='<i data-count="20" class="fa fa-shopping-cart fa-3x icon-white badge" style="background-color:#333;margin:0px;padding:0px; margin-top:5px;"></i>'</script>
+ -->
+	<div class="text-center"
+		style="color: green; font-size: 24px; font-weight: bold;">Order
+		Details</div>
+	<!-- Start of Product Items List -->
+	<div class="container">
+		<div class="table-responsive ">
+			<table class="table table-hover table-sm">
+				<thead
+					style="background-color: black; color: white; font-size: 14px; font-weight: bold;">
+					<tr>
+						<th>Picture</th>
+						<th>ProductName</th>
+						<th>OrderId</th>
+						<th>Quantity</th>
+						<th>Price</th>
+						<th>Time</th>
+						<th>Status</th>
+					</tr>
+				</thead>
+				<tbody
+					style="background-color: white; font-size: 15px; font-weight: bold;">
+					<%
+					for (OrderDetails order : orders) {
+					%>
+
+					<tr>
+						<td><img src="./ShowImage?pid=<%=order.getProductId()%>"
+							style="width: 50px; height: 50px;"></td>
+						<td><%=order.getProdName()%></td>
+						<td><%=order.getOrderId()%></td>
+						<td><%=order.getQty()%></td>
+						<td><%=order.getAmount()%></td>
+						<td><%=order.getTime()%></td>
+						<td class="text-success"><%=order.getShipped() == 0 ? "ORDER_PLACED" : "ORDER_SHIPPED"%></td>
+					</tr>
+
+					<%
+					}
+					%>
+
+				</tbody>
+			</table>
+		</div>
+	</div>
+	<!-- ENd of Product Items List -->
+
+
+	<%@ include file="footer.html"%>
+</body>
+</html>


### PR DESCRIPTION
This merge request introduces a new JSP page to display the order details for logged-in users. The page dynamically fetches order data via OrderService and displays it in a tabular format. The user must be logged in to access this page, and if the session expires, the user will be redirected to the login page. The details shown include product images, product names, order IDs, quantity, price, order time, and the status of the order (either "ORDER_PLACED" or "ORDER_SHIPPED").